### PR TITLE
Update theme with new font and colors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,17 +1,9 @@
-@font-face {
-  font-family: 'ESBuildTRIAL';
-  src: url('fonts/ESBuildTRIAL-Bold.otf') format('opentype');
-  font-weight: normal;
-  font-style: normal;
-}
-
 
 /* 1) Tüm sayfa arka planı */
 body {
-  font-family: ESBuildTRIAL, sans-serif; 
-  font-style:bold;
-  font-weight: 100;
-  background-color: rgb(250, 242, 210);  /* #fcf4de tonunda */
+  font-family: 'Playfair Display', serif;
+  background-color: #ffffff;
+  color: #000000;
   min-height: 100vh;
   margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -16,13 +16,16 @@
     href="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.19/build/css/intlTelInput.min.css"
   />
 
+  <!-- Google Font -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap" />
+
   <!-- Özel Stil -->
   <link rel="stylesheet" href="css/styles.css" />
   
 </head>
 <body>
   <div class="container py-5">
-<h1 class="text-center mb-4" style="color: rgb(215, 83, 43);">Rezervasyon Talep Formu</h1>    <div class="card shadow-sm mx-auto" style="max-width: 600px;">
+<h1 class="text-center mb-4">Rezervasyon Talep Formu</h1>    <div class="card shadow-sm mx-auto" style="max-width: 600px;">
   <!-- ↓ işte buraya ekliyoruz ↓ -->
 <div class="text-center mb-4">
   <img src="/images/MOMO LOGO.PNG" 


### PR DESCRIPTION
## Summary
- use Playfair Display font for a cleaner style
- set white background with black text
- remove inline color from heading

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a00728168832c822ab0b3e9ede185